### PR TITLE
add base background and font color for dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 :root {
     --background: #ffffff;
-    --foreground: #171717;
+    --foreground: #0a0a0a;
 }
 
 @theme inline {
@@ -15,7 +15,6 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --background: #0a0a0a;
-        --foreground: #ededed;
     }
 }
 
@@ -23,9 +22,11 @@
     font-family: "Pretendard", sans-serif;
 }
 
-body {
-    background: var(--background);
-    color: var(--foreground);
+@layer base {
+    body {
+        background: white;
+        color: var(--foreground);
+    }
 }
 
 button {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 


## 📝작업 내용

> 다크모드에 대해 배경색과 글자색 기본값 추가


## #️⃣ 테스트 결과

> 잘 나오는 것 확인


## ✍🏻 변경사항

> 다크모드, 기본 모드에 대해 기본 배경색은 white, 기본 글자색은 #0a0a0a로 변경


## 💬리뷰 요구사항(선택)


## 📎 참고 자료 (선택)
