### PR TITLE
render images in post detail & rental history

### DIFF
--- a/src/app/items/[itemId]/_component/ItemDetailClient.tsx
+++ b/src/app/items/[itemId]/_component/ItemDetailClient.tsx
@@ -39,7 +39,7 @@ function ItemDetailClient({ item }: { item: Item }) {
                 <div className="space-y-4">
                     <div className="aspect-square overflow-hidden bg-gray-100">
                         <img
-                            src={item.imageUrls[selectedImgIndex]}
+                            src={`/api/image?url=${item.imageUrls[selectedImgIndex]}`}
                             alt={item.title}
                             className="w-full h-full object-cover"
                         />
@@ -51,7 +51,7 @@ function ItemDetailClient({ item }: { item: Item }) {
                                 className="aspect-square bg-gray-100 border-2 border-transparent hover:border-gray-900 cursor-pointer transition-colors"
                             >
                                 <img
-                                    src={i}
+                                    src={`/api/image?url=${i}`}
                                     alt=""
                                     className={`w-full h-full object-cover transition-opacity ${selectedImgIndex === index ? "opacity-100" : "opacity-60"}`}
                                     onClick={() => setSelectedImgIndex(index)}

--- a/src/app/items/rent/history/_component/RentalHistoryClient.tsx
+++ b/src/app/items/rent/history/_component/RentalHistoryClient.tsx
@@ -454,9 +454,7 @@ function RentalHistoryClient() {
                                 <div className="p-6">
                                     <div className="flex gap-6">
                                         <img
-                                            src={
-                                                "https://www.dummyimage.com/150x150"
-                                            }
+                                            src={`/api/image?url=${rental.thumbnailUrl}`}
                                             alt={rental.title}
                                             className="w-32 h-32 object-cover bg-gray-100"
                                         />

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -51,4 +51,5 @@ export interface Rental {
     totalPrice: number;
     createdAt: string;
     updatedAt: string;
+    thumbnailUrl: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

> 물품 상세 및 대여 내역 페이지 이미지 렌더링 추가


## #️⃣ 테스트 결과

> 배포 url에서 테스트 필요


## ✍🏻 변경사항

> 물품 상세 및 대여 내역 페이지 이미지 렌더링 추가


## 💬리뷰 요구사항(선택)


## 📎 참고 자료 (선택)
