### PR TITLE
Feature/mypage stats 마이페이지 api

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -108,6 +108,7 @@ export default function MyPage() {
             name: user?.name || prev.name,
             email: user?.email || prev.email,
             point: user?.point || prev.point,
+            address: user?.address || prev.address,
         }));
     }, [user]);
 
@@ -214,8 +215,8 @@ export default function MyPage() {
                                                     <Link
                                                         href={item.href}
                                                         className={`block px-3 py-2 text-sm ${isActive
-                                                                ? " text-red-600 font-medium"
-                                                                : "text-gray-700 hover:bg-gray-100"
+                                                            ? " text-red-600 font-medium"
+                                                            : "text-gray-700 hover:bg-gray-100"
                                                             }`}
                                                     >
                                                         {item.label}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -5,7 +5,11 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getMyInfoApi } from "@/services/auth_copy.service";
+import {
+    getMyInfoApi,
+    getMyItemsCount,
+    getMyRentalsCount,
+} from "@/services/auth_copy.service";
 
 // 2. 타입/인터페이스
 interface UserProfile {
@@ -85,6 +89,20 @@ export default function MyPage() {
         gcTime: 10 * 60 * 1000, // 10 minutes
     });
 
+    const { data: myItemsCount = 0 } = useQuery({
+        queryKey: ["myItemsCount"],
+        queryFn: getMyItemsCount,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+    });
+
+    const { data: myRentalsCount = 0 } = useQuery({
+        queryKey: ["myRentalsCount"],
+        queryFn: getMyRentalsCount,
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+    });
+
     useEffect(() => {
         setProfile((prev) => ({
             ...prev,
@@ -94,11 +112,11 @@ export default function MyPage() {
         }));
     }, [user]);
 
-    const [statistics] = useState<Statistics>({
-        registeredItems: 3,
-        activeRentals: 2,
-        points: 15000,
-    });
+    const statistics: Statistics = {
+        registeredItems: myItemsCount,
+        activeRentals: myRentalsCount,
+        points: Number(user?.point) || 0,
+    };
 
     const handleInputChange = (field: keyof UserProfile, value: string) => {
         setProfile((prev) => ({ ...prev, [field]: value }));
@@ -197,11 +215,10 @@ export default function MyPage() {
                                                 <li key={item.id}>
                                                     <Link
                                                         href={item.href}
-                                                        className={`block px-3 py-2 text-sm ${
-                                                            isActive
+                                                        className={`block px-3 py-2 text-sm ${isActive
                                                                 ? " text-red-600 font-medium"
                                                                 : "text-gray-700 hover:bg-gray-100"
-                                                        }`}
+                                                            }`}
                                                     >
                                                         {item.label}
                                                     </Link>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -22,7 +22,6 @@ interface UserProfile {
 interface Statistics {
     registeredItems: number;
     activeRentals: number;
-    points: number;
 }
 
 // 3. 상수
@@ -112,10 +111,9 @@ export default function MyPage() {
         }));
     }, [user]);
 
-    const statistics: Statistics = {
+    const statistics = {
         registeredItems: myItemsCount,
         activeRentals: myRentalsCount,
-        points: Number(user?.point) || 0,
     };
 
     const handleInputChange = (field: keyof UserProfile, value: string) => {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -47,19 +47,14 @@ export async function signup(
   account: string | null,
   phone: string | null
 ): Promise<AuthSuccessResponse> {
-  // 추가 정보를 additionalInfo 필드에 JSON 문자열로 담기
-  const additionalInfo = {
-    address,
-    bank,
-    account,
-    phone,
-  };
-
   const requestData: SignupRequest = {
     email,
     password,
     name,
-    additionalInfo: JSON.stringify(additionalInfo),
+    address,
+    bank,
+    account,
+    phone,
   };
 
   // Idempotency-Key 생성 (중복 요청 방지용)

--- a/src/services/auth_copy.service.ts
+++ b/src/services/auth_copy.service.ts
@@ -117,3 +117,50 @@ export async function googleLogin(idToken: string): Promise<void> {
         throw new Error(data.message || "구글 로그인에 실패했습니다.");
     }
 }
+
+export async function getMyItemsCount(): Promise<number> {
+    try {
+        const response = await fetch("/api/items/my", {
+            method: "GET",
+            credentials: "include",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cache: "no-store",
+        });
+
+        const data = await response.json();
+
+        if (data.success && data.data?.page) {
+            return data.data.page.totalElements;
+        }
+        return 0;
+    } catch (err) {
+        console.error("Failed to fetch my items count:", err);
+        return 0;
+    }
+}
+
+export async function getMyRentalsCount(): Promise<number> {
+    try {
+        const response = await fetch("/api/users/me/rentals?role=BORROWER", {
+            method: "GET",
+            credentials: "include",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cache: "no-store",
+        });
+
+        const data = await response.json();
+
+        if (data.success && data.data?.page) {
+            return data.data.page.totalElements;
+        }
+        return 0;
+    } catch (err) {
+        console.error("Failed to fetch my rentals count:", err);
+        return 0;
+    }
+}
+

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -25,7 +25,10 @@ export interface SignupRequest {
   email: string;
   password: string;
   name: string;
-  additionalInfo: string | null;  // 주소, 은행, 계좌, 전화번호 등의 추가 정보를 JSON 문자열로 저장
+  address: string | null;
+  bank: string | null;
+  account: string | null;
+  phone: string | null;
 }
 
 // 회원가입 응답 (백엔드)

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -42,12 +42,25 @@ export interface Rental {
     endDate: string;
     receiveMethod: "MEETUP" | "PARCEL";
     status:
-        | "REQUESTED"
-        | "CONFIRMED"
-        | "IN_USE"
-        | "RETURNED"
-        | "ENDED"
-        | "CANCELED";
+    | "REQUESTED"
+    | "CONFIRMED"
+    | "IN_USE"
+    | "RETURNED"
+    | "ENDED"
+    | "CANCELED";
+}
+
+// 페이지네이션 응답 타입
+export interface PageInfo {
+    size: number;
+    number: number;
+    totalElements: number;
+    totalPages: number;
+}
+
+export interface PagedResponse<T> {
+    content: T[];
+    page: PageInfo;
     totalPrice: number;
     createdAt: string;
     updatedAt: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -61,6 +61,10 @@ export interface PageInfo {
 export interface PagedResponse<T> {
     content: T[];
     page: PageInfo;
+}
+
+// 대여 전용 페이지네이션 응답 타입
+export interface RentalPagedResponse extends PagedResponse<Rental> {
     totalPrice: number;
     createdAt: string;
     updatedAt: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex. #46 


## 📝작업 내용

> 마이페이지에서 사용자 정보와 통계 데이터를 실제 API로부터 가져오도록 구현했습니다.
(등록한 물품 개수, 진행중 대여 개수를 실시간 API 데이터로 표시, 사용자 주소 정보를 API로부터 가져와 표시, 페이지네이션 응답 타입 정의 및 분리)


## #️⃣ 테스트 결과

> 마이페이지 접속 시 통계 데이터가 실시간으로 표시됨, 등록한 물품 개수, 진행중 대여 개수, 사용자 주소 정보 정상 표시, 새로고침 후에도 데이터 유지 확인 완료.


## ✍🏻 변경사항

> API 서비스 함수 추가 (services/auth_copy.service.ts) , 타입 정의(types/common.ts), 하드코딩된 통계 데이터 제거 및 사용자 주소 정보 업데이트 로직 추가.


## 💬리뷰 요구사항(선택)

> 현재 등록 물품/대여 개수를 별도 API로 호출하고 있는데, 참고로 (`/api/items/my`, `/api/users/me/rentals`)를 호출해서 `page.totalElements`로 가져오고 있습니다.
> 그런데 제가 /auth/me 응답에 `postCount`, `rentalCount` 필드가 있는 걸 좀 뒤늦게 확인해서요...! 요걸 활용하는게 더 나았을까요...? 흑흑 더 효율적인 방법이 있다면 제안 부탁드립니다...!

## 📎 참고 자료 (선택)

> 
<img width="1351" height="563" alt="스크린샷 2026-04-06 181423" src="https://github.com/user-attachments/assets/c0e59741-755f-486b-93bb-2aa94ec942c8" />
